### PR TITLE
Nessie: Automatically create entities for implied namespaces

### DIFF
--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
@@ -36,6 +36,7 @@ public final class NessieUtil {
 
   public static final String NESSIE_CONFIG_PREFIX = "nessie.";
   static final String APPLICATION_TYPE = "application-type";
+  static final String CREATE_IMPLIED_NAMESPACES = "create-implied-namespaces";
 
   private NessieUtil() {}
 
@@ -88,5 +89,16 @@ public final class NessieUtil {
   private static String commitAuthor(Map<String, String> catalogOptions) {
     return Optional.ofNullable(catalogOptions.get(CatalogProperties.USER))
         .orElseGet(() -> System.getProperty("user.name"));
+  }
+
+  /**
+   * Indicates whether the Nessie Catalog should automatically create namespaces implied by table
+   * identifiers.
+   *
+   * @param catalogOptions The options where to look for configuration settings.
+   */
+  static boolean shouldCreateImpliedNamespaces(Map<String, String> catalogOptions) {
+    String create = catalogOptions.get(CREATE_IMPLIED_NAMESPACES);
+    return create == null || Boolean.parseBoolean(create); // Note: `true` if not set
   }
 }

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
@@ -36,7 +36,7 @@ public final class NessieUtil {
 
   public static final String NESSIE_CONFIG_PREFIX = "nessie.";
   static final String APPLICATION_TYPE = "application-type";
-  static final String CREATE_IMPLIED_NAMESPACES = "create-implied-namespaces";
+  static final String IGNORE_IMPLIED_NAMESPACES = "ignore-implied-namespaces-on-create";
 
   private NessieUtil() {}
 
@@ -98,7 +98,7 @@ public final class NessieUtil {
    * @param catalogOptions The options where to look for configuration settings.
    */
   static boolean shouldCreateImpliedNamespaces(Map<String, String> catalogOptions) {
-    String create = catalogOptions.get(CREATE_IMPLIED_NAMESPACES);
-    return create == null || Boolean.parseBoolean(create); // Note: `true` if not set
+    return !Boolean.parseBoolean(
+        catalogOptions.get(IGNORE_IMPLIED_NAMESPACES)); // Note: `true` if not set
   }
 }

--- a/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
@@ -54,6 +54,7 @@ import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.jaxrs.ext.NessieJaxRsExtension;
 import org.projectnessie.jaxrs.ext.NessieUri;
 import org.projectnessie.model.Branch;
+import org.projectnessie.model.Namespace;
 import org.projectnessie.model.Reference;
 import org.projectnessie.model.Tag;
 import org.projectnessie.server.store.TableCommitMetaStoreWorker;
@@ -178,6 +179,11 @@ public abstract class BaseTestIceberg {
   void createBranch(String name, String hash, String sourceRef)
       throws NessieNotFoundException, NessieConflictException {
     api.createReference().reference(Branch.of(name, hash)).sourceRefName(sourceRef).create();
+  }
+
+  void createNamespace(String refName, Namespace namespace)
+      throws NessieNotFoundException, NessieConflictException {
+    api.createNamespace().refName(refName).namespace(namespace).create();
   }
 
   @AfterEach

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNamespace.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNamespace.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.types.Types;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.IcebergTable;
 
@@ -71,6 +72,29 @@ public class TestNamespace extends BaseTestIceberg {
     Assertions.assertThat(namespaces).isNotNull().hasSize(2);
     namespaces = catalog.listNamespaces(Namespace.of("b"));
     Assertions.assertThat(namespaces).isNotNull().hasSize(2);
+  }
+
+  @Test
+  public void testAutoCreateNamespaceContent() throws NessieNotFoundException {
+    ContentKey nsKey1 = ContentKey.of("a", "b");
+    ContentKey nsKey2 = ContentKey.of("a", "b", "c");
+    ContentKey nsKey3 = ContentKey.of("a");
+    createTable(TableIdentifier.parse(nsKey1.toString() + ".t1"));
+    createTable(TableIdentifier.parse(nsKey2.toString() + ".t2"));
+    createTable(TableIdentifier.parse(nsKey3.toString() + ".t3"));
+
+    Map<ContentKey, Content> contentMap =
+        api.getContent().refName(BRANCH).key(nsKey1).key(nsKey2).key(nsKey3).get();
+
+    Assertions.assertThat(contentMap)
+        .extractingByKey(nsKey1)
+        .isInstanceOf(org.projectnessie.model.Namespace.class);
+    Assertions.assertThat(contentMap)
+        .extractingByKey(nsKey2)
+        .isInstanceOf(org.projectnessie.model.Namespace.class);
+    Assertions.assertThat(contentMap)
+        .extractingByKey(nsKey3)
+        .isInstanceOf(org.projectnessie.model.Namespace.class);
   }
 
   @Test

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergClient.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergClient.java
@@ -151,7 +151,7 @@ public class TestNessieIcebergClient extends BaseTestIceberg {
     String branch = "testFindImpliedNamespacesDisabled";
     NessieIcebergClient client =
         new NessieIcebergClient(
-            api, branch, null, ImmutableMap.of(NessieUtil.CREATE_IMPLIED_NAMESPACES, "false"));
+            api, branch, null, ImmutableMap.of(NessieUtil.IGNORE_IMPLIED_NAMESPACES, "true"));
 
     Assertions.assertThat(client.findImpliedNamespaces(ContentKey.of("a", "b", "Table"))).isEmpty();
   }


### PR DESCRIPTION
When namespace properties are concerned Nessie treats namespaces as entities and assigns content IDs to them.

Previously, `NessieCatalog` permitted creating tables with identifiers containing namespace elements that were entities on the Nessie Server. Those implicit namespaces would still be reflected in the `SupportsNamespaces.listNamespaces` method, but they would not be given content IDs on the Nessie side.

This change makes `NessieCatalog` automatically create `Namespace` content objects implied by the table identifier at table creation time.

This change should result in more consistent data on the Nessie Server side, where all `Namespace` objects would be entities regardless of having or not having properties set on them on the Iceberg side.

A new `NessieCatalog` configuration option is added to allow users to request old behaviour, if desired. The default is new behaviour, that is automatically creating implied Namespaces